### PR TITLE
修复支付状态验证逻辑 - 防止未完成支付被误认为成功

### DIFF
--- a/index.html
+++ b/index.html
@@ -2927,7 +2927,8 @@
                     ...userResults,
                     orderId: orderId,
                     timestamp: Date.now(),
-                    paymentInitiated: true
+                    paymentInitiated: true,
+                    paymentStatus: 'pending'  // 添加支付状态标记
                 };
 
                 localStorage.setItem('pendingResults', JSON.stringify(dataToSave));
@@ -2954,9 +2955,35 @@
             }
         }
 
+        // 清理过期的pending支付数据
+        function cleanupExpiredPaymentData() {
+            const PAYMENT_TIMEOUT = 30 * 60 * 1000; // 30分钟超时
+
+            ['pendingResults', 'ecrBackupResults'].forEach(key => {
+                const data = localStorage.getItem(key);
+                if (data) {
+                    try {
+                        const parsed = JSON.parse(data);
+                        if (parsed.paymentStatus === 'pending' &&
+                            parsed.timestamp &&
+                            (Date.now() - parsed.timestamp) > PAYMENT_TIMEOUT) {
+                            localStorage.removeItem(key);
+                            console.log(`已清理过期的${key}数据`);
+                        }
+                    } catch (error) {
+                        console.error(`清理${key}数据时出错:`, error);
+                        localStorage.removeItem(key); // 清理损坏的数据
+                    }
+                }
+            });
+        }
+
         // 手动检查支付状态
         function checkPaymentStatusManually() {
             console.log('手动检查支付状态...');
+
+            // 先清理过期数据
+            cleanupExpiredPaymentData();
 
             // 检查localStorage中是否有支付数据
             const pendingResults = localStorage.getItem('pendingResults');
@@ -2971,25 +2998,34 @@
                     const userResults = JSON.parse(dataToUse);
                     console.log('找到支付数据，恢复用户结果:', userResults);
 
-                    // 设置测评结果
-                    testResults = userResults;
+                    // 检查支付状态
+                    if (userResults.paymentStatus === 'completed') {
+                        // 支付已完成，显示详细报告
+                        testResults = userResults;
 
-                    // 清除临时数据
-                    localStorage.removeItem('pendingResults');
-                    localStorage.removeItem('ecrBackupResults');
+                        // 清除临时数据
+                        localStorage.removeItem('pendingResults');
+                        localStorage.removeItem('ecrBackupResults');
 
-                    // 标记为已支付
-                    paymentStatus.isPaid = true;
+                        // 标记为已支付
+                        paymentStatus.isPaid = true;
 
-                    // 关闭支付模态框
-                    closePaymentModal();
+                        // 关闭支付模态框
+                        closePaymentModal();
 
-                    // 显示详细报告
-                    setTimeout(() => {
-                        showDetailedReportAfterPayment();
-                    }, 500);
+                        // 显示详细报告
+                        setTimeout(() => {
+                            showDetailedReportAfterPayment();
+                        }, 500);
 
-                    showMessage('支付状态确认成功！正在显示详细报告...', 'success');
+                        showMessage('支付状态确认成功！正在显示详细报告...', 'success');
+                    } else if (userResults.paymentStatus === 'pending') {
+                        // 支付仍在进行中或未完成
+                        showMessage('支付尚未完成，请先完成支付后再查询状态', 'warning');
+                    } else {
+                        // 未知状态
+                        showMessage('支付状态异常，请重新支付', 'error');
+                    }
 
                 } catch (error) {
                     console.error('解析支付数据失败:', error);
@@ -4175,6 +4211,9 @@
             console.log('页面加载完成，开始初始化...');
             console.log('当前URL:', window.location.href);
             console.log('URL参数:', window.location.search);
+
+            // 清理过期的支付数据
+            cleanupExpiredPaymentData();
 
             // 检查是否从支付页面返回
             if (checkPaymentSuccess()) {

--- a/payment-success.html
+++ b/payment-success.html
@@ -219,6 +219,34 @@
             console.log('localStorage pendingResults:', localStorage.getItem('pendingResults'));
             console.log('localStorage ecrBackupResults:', localStorage.getItem('ecrBackupResults'));
 
+            // 更新localStorage中的支付状态为已完成
+            const pendingResults = localStorage.getItem('pendingResults');
+            const backupResults = localStorage.getItem('ecrBackupResults');
+
+            if (pendingResults) {
+                try {
+                    const data = JSON.parse(pendingResults);
+                    data.paymentStatus = 'completed';
+                    data.paymentCompletedAt = Date.now();
+                    localStorage.setItem('pendingResults', JSON.stringify(data));
+                    console.log('已更新pendingResults支付状态为completed');
+                } catch (error) {
+                    console.error('更新pendingResults支付状态失败:', error);
+                }
+            }
+
+            if (backupResults) {
+                try {
+                    const data = JSON.parse(backupResults);
+                    data.paymentStatus = 'completed';
+                    data.paymentCompletedAt = Date.now();
+                    localStorage.setItem('ecrBackupResults', JSON.stringify(data));
+                    console.log('已更新ecrBackupResults支付状态为completed');
+                } catch (error) {
+                    console.error('更新ecrBackupResults支付状态失败:', error);
+                }
+            }
+
             if (sessionId) {
                 // 跳转到主页面，主页面会检测支付成功状态
                 const targetUrl = `index.html?session_id=${sessionId}`;


### PR DESCRIPTION
## 问题描述

用户点击"前往支付"跳转到Stripe后，如果没有完成支付就回到页面点击"查询支付状态"，系统会误认为支付成功并显示详细报告。

**预期行为**：提示没有找到支付记录  
**实际行为**：显示支付成功

## 根本原因

当用户点击"前往支付"时，系统就将测评数据保存到localStorage中，无论用户是否真正完成支付。当用户回来点击"检查支付状态"时，系统发现localStorage中有数据就误认为支付成功了。

## 解决方案

### 1. 添加支付状态标记
- 在支付发起时保存 `paymentStatus: 'pending'`
- 只有在支付成功页面才更新为 `paymentStatus: 'completed'`

### 2. 改进支付状态检查逻辑
- `checkPaymentStatusManually()` 函数现在检查 `paymentStatus` 字段
- 只有状态为 `'completed'` 时才认为支付成功
- 状态为 `'pending'` 时提示用户支付尚未完成

### 3. 支付成功页面自动标记
- `payment-success.html` 在跳转回主页面前自动将localStorage中的支付状态更新为 `'completed'`

### 4. 添加过期数据清理机制
- 自动清理超过30分钟的pending支付数据
- 页面加载时和手动检查支付状态时都会执行清理

## 修改的文件

- `index.html`: 修改支付状态检查逻辑，添加状态标记和清理机制
- `payment-success.html`: 添加支付完成状态标记

## 测试场景

1. **正常支付流程**：完成测评 → 点击"前往支付" → 完成Stripe支付 → 自动跳转回来显示详细报告 ✅

2. **未完成支付流程**：完成测评 → 点击"前往支付" → 不完成支付直接关闭 → 回到页面点击"检查支付状态" → 提示"支付尚未完成" ✅

3. **过期数据清理**：支付发起30分钟后，pending数据会被自动清理 ✅

## 影响范围

- ✅ 不影响正常的支付流程
- ✅ 修复了未完成支付被误认为成功的问题
- ✅ 改进了用户体验和状态提示
- ✅ 添加了数据清理机制防止localStorage积累过期数据

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author